### PR TITLE
Implement search feature in add-ons page + enable user customization of add-ons source via Customize settings

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -112,9 +112,6 @@ android {
             // Need to replicate default debug config features
             signingConfig signingConfigs.debug
             debuggable true
-            // Use custom allowed addon list
-            buildConfigField "String", "AMO_ACCOUNT", "\"16201230\""
-            buildConfigField "String", "AMO_COLLECTION", "\"What-I-want-on-Fenix\""
         }
         forkRelease releaseTemplate >> {
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
@@ -124,9 +121,6 @@ android {
             manifestPlaceholders = [
                     "deepLinkScheme": deepLinkSchemeValue
             ]
-            // Use custom allowed addon list
-            buildConfigField "String", "AMO_ACCOUNT", "\"16201230\""
-            buildConfigField "String", "AMO_COLLECTION", "\"What-I-want-on-Fenix\""
         }
         
     }

--- a/app/src/main/java/network/novak/fenix/components/PagedAddonCollectionProvider.kt
+++ b/app/src/main/java/network/novak/fenix/components/PagedAddonCollectionProvider.kt
@@ -62,14 +62,22 @@ class PagedAddonCollectionProvider(
     private val context: Context,
     private val client: Client,
     private val serverURL: String = DEFAULT_SERVER_URL,
-    private val collectionAccount: String = DEFAULT_COLLECTION_ACCOUNT,
-    private val collectionName: String = DEFAULT_COLLECTION_NAME,
+    private var collectionAccount: String = DEFAULT_COLLECTION_ACCOUNT,
+    private var collectionName: String = DEFAULT_COLLECTION_NAME,
     private val maxCacheAgeInMinutes: Long = -1
 ) : AddonsProvider {
 
     private val logger = Logger("PagedAddonCollectionProvider")
 
     private val diskCacheLock = Any()
+
+    fun setCollectionAccount(account: String) {
+        collectionAccount = account
+    }
+
+    fun setCollectionName(collection: String) {
+        collectionName = collection
+    }
 
     /**
      * Interacts with the collections endpoint to provide a list of available
@@ -215,6 +223,11 @@ class PagedAddonCollectionProvider(
 
     private fun getBaseCacheFile(context: Context): File {
         return File(context.filesDir, COLLECTION_FILE_NAME.format(collectionAccount, collectionName))
+    }
+
+    fun deleteCacheFile(context: Context): Boolean {
+        val file = getBaseCacheFile(context)
+        return if (file.exists()) file.delete() else false
     }
 }
 

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -9,8 +9,6 @@ import android.content.Intent
 import androidx.core.content.getSystemService
 import androidx.core.net.toUri
 import mozilla.components.feature.addons.AddonManager
-import mozilla.components.feature.addons.AddonsProvider
-import mozilla.components.feature.addons.amo.AddonCollectionProvider
 import mozilla.components.feature.addons.migration.DefaultSupportedAddonsChecker
 import mozilla.components.feature.addons.migration.SupportedAddonsChecker
 import mozilla.components.feature.addons.update.AddonUpdater
@@ -18,9 +16,9 @@ import mozilla.components.feature.addons.update.DefaultAddonUpdater
 import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 import mozilla.components.support.migration.state.MigrationStore
 import network.novak.fenix.components.PagedAddonCollectionProvider
-import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.components.metrics.AppStartupTelemetry
+import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.utils.ClipboardHandler
 import org.mozilla.fenix.utils.Mockable
 import org.mozilla.fenix.utils.Settings
@@ -73,18 +71,17 @@ class Components(private val context: Context) {
     }
 
     val addonCollectionProvider by lazy {
-        if (!BuildConfig.AMO_COLLECTION.isNullOrEmpty()) {
-            PagedAddonCollectionProvider(
-                context,
-                core.client,
-                collectionAccount = BuildConfig.AMO_ACCOUNT,
-                collectionName = BuildConfig.AMO_COLLECTION,
-                maxCacheAgeInMinutes = DAY_IN_MINUTES
-            )
-        } else {
-            PagedAddonCollectionProvider(context, core.client, maxCacheAgeInMinutes = DAY_IN_MINUTES)
-        }
+        val addonsAccount = context.settings().customAddonsAccount
+        val addonsCollection = context.settings().customAddonsCollection
+        PagedAddonCollectionProvider(
+            context,
+            core.client,
+            collectionAccount = addonsAccount,
+            collectionName = addonsCollection,
+            maxCacheAgeInMinutes = DAY_IN_MINUTES
+        )
     }
+
 
     val appStartupTelemetry by lazy { AppStartupTelemetry(analytics.metrics) }
 
@@ -106,6 +103,15 @@ class Components(private val context: Context) {
 
     val addonManager by lazy {
         AddonManager(core.store, core.engine, addonCollectionProvider, addonUpdater)
+    }
+
+    fun updateAddonManager() {
+        addonCollectionProvider.deleteCacheFile(context)
+
+        val addonsAccount = context.settings().customAddonsAccount
+        val addonsCollection = context.settings().customAddonsCollection
+        addonCollectionProvider.setCollectionAccount(addonsAccount)
+        addonCollectionProvider.setCollectionName(addonsCollection)
     }
 
     val analytics by lazy { Analytics(context) }

--- a/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
@@ -57,6 +58,7 @@ class CustomizationFragment : PreferenceFragmentCompat() {
         setupRadioGroups()
         setupToolbarCategory()
         setupHomeCategory()
+        setupAddonsCustomizationCategory()
     }
 
     private fun setupRadioGroups() {
@@ -149,5 +151,18 @@ class CustomizationFragment : PreferenceFragmentCompat() {
             isChecked = context.settings().showTopFrecentSites
             onPreferenceChangeListener = SharedPreferenceUpdater()
         }
+    }
+
+    private fun setupAddonsCustomizationCategory() {
+        requirePreference<EditTextPreference>(R.string.pref_key_addons_custom_account).apply {
+            text = context.settings().customAddonsAccount
+            onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
+
+        requirePreference<EditTextPreference>(R.string.pref_key_addons_custom_collection).apply {
+            text = context.settings().customAddonsCollection
+            onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
+
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/SharedPreferenceUpdater.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SharedPreferenceUpdater.kt
@@ -6,6 +6,8 @@ package org.mozilla.fenix.settings
 
 import androidx.core.content.edit
 import androidx.preference.Preference
+import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
 
 /**
@@ -15,10 +17,21 @@ import org.mozilla.fenix.ext.settings
 open class SharedPreferenceUpdater : Preference.OnPreferenceChangeListener {
 
     override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
-        val newBooleanValue = newValue as? Boolean ?: return false
-        preference.context.settings().preferences.edit {
-            putBoolean(preference.key, newBooleanValue)
+        if (newValue is Boolean) {
+            preference.context.settings().preferences.edit {
+                putBoolean(preference.key, newValue)
+            }
+        } else if (newValue is String) {
+            preference.context.settings().preferences.edit {
+                putString(preference.key, newValue)
+            }
+
+            if (preference.key == preference.context.getString(R.string.pref_key_addons_custom_account) ||
+                preference.key == preference.context.getString(R.string.pref_key_addons_custom_collection)) {
+                preference.context.components.updateAddonManager()
+            }
         }
+
         return true
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -15,6 +15,7 @@ import android.view.accessibility.AccessibilityManager
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.PRIVATE
 import androidx.lifecycle.LifecycleOwner
+import androidx.preference.EditTextPreference
 import mozilla.components.feature.sitepermissions.SitePermissionsRules
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.Action
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.AutoplayAction
@@ -812,6 +813,16 @@ class Settings(private val appContext: Context) : PreferencesHolder {
             appContext.getPreferenceKey(R.string.pref_key_open_tabs_count),
             0
         )
+
+    val customAddonsAccount by stringPreference(
+        appContext.getPreferenceKey(R.string.pref_key_addons_custom_account),
+        "16201230"
+    )
+
+    val customAddonsCollection by stringPreference(
+        appContext.getPreferenceKey(R.string.pref_key_addons_custom_collection),
+        "What-I-want-on-Fenix"
+    )
 
     private var savedLoginsSortingStrategyString by stringPreference(
         appContext.getPreferenceKey(R.string.pref_key_saved_logins_sorting_strategy),

--- a/app/src/main/res/menu/addons_menu.xml
+++ b/app/src/main/res/menu/addons_menu.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?><!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/search"
+        android:icon="@drawable/ic_search"
+        android:title="@string/addons_search_hint"
+        app:iconTint="?primaryText"
+        app:actionViewClass="androidx.appcompat.widget.SearchView"
+        android:contentDescription="@string/addons_search_hint"
+        app:showAsAction="ifRoom|collapseActionView" />
+</menu>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -126,6 +126,11 @@
     <!-- Customization Settings -->
     <string name="pref_home_category" translatable="false">pref_home_category</string>
 
+    <!-- Add-ons Source Customization Settings -->
+    <string name="pref_addons_settings_category" translatable="false">pref_addons_settings_category</string>
+    <string name="pref_key_addons_custom_account" translatable="false">pref_key_addons_custom_account</string>
+    <string name="pref_key_addons_custom_collection" translatable="false">pref_key_addons_custom_collection</string>
+
     <!-- Tracking Protection Settings -->
     <string name="pref_key_etp_learn_more" translatable="false">pref_key_etp_learn_more</string>
     <string name="pref_key_tracking_protection_settings" translatable="false">pref_key_tracking_protection_settings</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -324,6 +324,8 @@
     <string name="preferences_external_download_manager">External download manager</string>
     <!-- Preference for add_ons -->
     <string name="preferences_addons">Add-ons</string>
+    <!-- Preference for add-ons custom source -->
+    <string name="preferences_addons_customization">Configure custom add-ons source</string>
     <!-- Placeholder text shown in the search bar before a user enters text -->
     <string name="addons_search_hint">Search add-ons</string>
     <!-- Preference for notifications -->
@@ -1527,6 +1529,11 @@
     <string name="top_sites_max_limit_confirmation_button">OK, Got It</string>
     <!-- Label for the show most visited sites preference -->
     <string name="top_sites_toggle_top_frecent_sites">Show most visited sites</string>
+
+    <!-- Label for add-ons custom source account -->
+    <string name="addons_custom_source_account">Set custom add-ons account</string>
+    <!-- Label for add-ons custom source collection -->
+    <string name="addons_custom_source_collection">Set custom add-ons collection</string>
 
     <!-- Content description for close button in collection placeholder. -->
     <string name="remove_home_collection_placeholder_content_description">Remove</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -324,6 +324,8 @@
     <string name="preferences_external_download_manager">External download manager</string>
     <!-- Preference for add_ons -->
     <string name="preferences_addons">Add-ons</string>
+    <!-- Placeholder text shown in the search bar before a user enters text -->
+    <string name="addons_search_hint">Search add-ons</string>
     <!-- Preference for notifications -->
     <string name="preferences_notifications">Notifications</string>
 

--- a/app/src/main/res/xml/customization_preferences.xml
+++ b/app/src/main/res/xml/customization_preferences.xml
@@ -61,4 +61,18 @@
             android:key="@string/pref_key_enable_top_frecent_sites"
             android:title="@string/top_sites_toggle_top_frecent_sites" />
     </androidx.preference.PreferenceCategory>
+
+    <androidx.preference.PreferenceCategory
+        android:key="@string/pref_addons_settings_category"
+        android:layout="@layout/preference_cat_style"
+        android:title="@string/preferences_addons_customization"
+        app:allowDividerAbove="false"
+        app:iconSpaceReserved="false">
+        <androidx.preference.EditTextPreference
+            android:key="@string/pref_key_addons_custom_account"
+            android:title="@string/addons_custom_source_account" />
+        <androidx.preference.EditTextPreference
+            android:key="@string/pref_key_addons_custom_collection"
+            android:title="@string/addons_custom_source_collection" />
+    </androidx.preference.PreferenceCategory>
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Implemented a search feature in the add-ons page. This should help users find the add-on they want to install much more easily, especially when our custom list is very long and difficult to search through manually.

### Demo
![addons search](https://user-images.githubusercontent.com/17151327/91890245-137e3600-ec87-11ea-890a-ebdc9b44a43a.gif)

Enjoy a simpler add-on experience!

Also, implemented new customization settings in the Customize menu, to allow users to choose their own custom add-ons collection as the source of the add-ons. This allows users to use their own custom lists and they do not have to wait on @interfect to update his list with the add-ons users want! This reduces the "enable add-on" requests/issues in this repo! More details in following comment.