### PR TITLE
Add more tab tray customizations

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
@@ -59,6 +59,8 @@ class CustomizationFragment : PreferenceFragmentCompat() {
         setupToolbarCategory()
         setupHomeCategory()
         setupAddonsCustomizationCategory()
+        setupTabTrayDirectionCategory()
+        setupTabTrayNewTabType()
     }
 
     private fun setupRadioGroups() {
@@ -163,6 +165,42 @@ class CustomizationFragment : PreferenceFragmentCompat() {
             text = context.settings().customAddonsCollection
             onPreferenceChangeListener = SharedPreferenceUpdater()
         }
+    }
 
+    private fun setupTabTrayDirectionCategory() {
+        val alwaysTop = requirePreference<RadioButtonPreference>(R.string.pref_key_tab_tray_always_top).apply {
+            onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
+        val alwaysBottom = requirePreference<RadioButtonPreference>(R.string.pref_key_tab_tray_always_bottom).apply {
+            onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
+        val sameDirection = requirePreference<RadioButtonPreference>(R.string.pref_key_tab_tray_same_direction).apply {
+            onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
+        val oppositeDirection = requirePreference<RadioButtonPreference>(R.string.pref_key_tab_tray_opposite_direction).apply {
+            onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
+
+        val settings = requireContext().settings()
+        alwaysTop.setCheckedWithoutClickListener(settings.tabTrayAlwaysTop)
+        alwaysBottom.setCheckedWithoutClickListener(settings.tabTrayAlwaysBottom)
+        sameDirection.setCheckedWithoutClickListener(settings.tabTraySameDirection)
+        oppositeDirection.setCheckedWithoutClickListener(settings.tabTrayOppositeDirection)
+
+        addToRadioGroup(sameDirection, oppositeDirection, alwaysTop, alwaysBottom)
+    }
+
+    private fun setupTabTrayNewTabType() {
+        val fab = requirePreference<RadioButtonPreference>(R.string.pref_key_tab_tray_new_tab_fab).apply {
+            onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
+        val bar = requirePreference<RadioButtonPreference>(R.string.pref_key_tab_tray_new_tab_bar).apply {
+            onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
+
+        val settings = requireContext().settings()
+        fab.setCheckedWithoutClickListener(settings.useNewTabFab)
+        bar.setCheckedWithoutClickListener(settings.useNewTabBar)
+        addToRadioGroup(fab, bar)
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
@@ -21,7 +21,8 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.component_tabstray.view.*
+import kotlinx.android.synthetic.main.component_tabstray_bottom.view.*
+import kotlinx.android.synthetic.main.component_tabstray_fab.view.*
 import kotlinx.android.synthetic.main.fragment_tab_tray_dialog.*
 import kotlinx.android.synthetic.main.fragment_tab_tray_dialog.view.*
 import kotlinx.coroutines.Dispatchers
@@ -66,7 +67,8 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), UserInteractionHandler 
     private lateinit var tabTrayDialogStore: TabTrayDialogFragmentStore
 
     private val snackbarAnchor: View?
-        get() = null
+        get() = if (tabTrayView.fabView.new_tab_button.isVisible) tabTrayView.fabView.new_tab_button
+        else null
 
     private val collectionStorageObserver = object : TabCollectionStorage.Observer {
         override fun onCollectionCreated(title: String, sessions: List<Session>) {

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -15,7 +15,6 @@ import android.view.accessibility.AccessibilityManager
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.PRIVATE
 import androidx.lifecycle.LifecycleOwner
-import androidx.preference.EditTextPreference
 import mozilla.components.feature.sitepermissions.SitePermissionsRules
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.Action
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.AutoplayAction
@@ -540,8 +539,49 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         default = !touchExplorationIsEnabled && !switchServiceIsEnabled
     )
 
+    var tabTraySameDirection by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_tab_tray_same_direction),
+        default = false
+    )
+
+    var tabTrayOppositeDirection by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_tab_tray_opposite_direction),
+        default = true
+    )
+
+    var tabTrayAlwaysTop by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_tab_tray_always_top),
+        default = false
+    )
+
+    var tabTrayAlwaysBottom by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_tab_tray_always_bottom),
+        default = false
+    )
+
     val toolbarPosition: ToolbarPosition
         get() = if (shouldUseBottomToolbar) ToolbarPosition.BOTTOM else ToolbarPosition.TOP
+
+    val shouldUseTopTabTray: Boolean
+    get() = if (tabTraySameDirection) {
+        !shouldUseBottomToolbar
+    } else {
+        if (tabTrayOppositeDirection) {
+            shouldUseBottomToolbar
+        } else {
+            tabTrayAlwaysTop
+        }
+    }
+
+    val useNewTabFab: Boolean by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_tab_tray_new_tab_fab),
+        default = false
+    )
+
+    val useNewTabBar: Boolean by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_tab_tray_new_tab_bar),
+        default = true
+    )
 
     var shouldStripUrl by booleanPreference(
         appContext.getPreferenceKey(R.string.pref_key_strip_url),

--- a/app/src/main/res/layout/component_tabstray_bottom.xml
+++ b/app/src/main/res/layout/component_tabstray_bottom.xml
@@ -6,44 +6,45 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/tab_wrapper"
-    style="@style/TopSheetModal"
+    style="@style/BottomSheetModal"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:backgroundTint="@color/foundation_normal_theme"
-    app:layout_behavior="org.mozilla.fenix.components.topsheet.TopSheetBehavior">
+    app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
 
     <View
         android:id="@+id/handle"
         android:layout_width="0dp"
         android:layout_height="3dp"
-        android:layout_marginBottom="8dp"
+        android:layout_marginTop="8dp"
         android:background="@color/secondary_text_normal_theme"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintWidth_percent="0.1" />
 
     <TextView
         android:id="@+id/tab_tray_empty_view"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         android:focusable="true"
         android:focusableInTouchMode="true"
         android:gravity="center_horizontal"
-        android:paddingBottom="80dp"
+        android:paddingTop="80dp"
         android:text="@string/no_open_tabs_description"
         android:textColor="?secondaryText"
         android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/divider" />
+        app:layout_constraintTop_toBottomOf="@id/topBar" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/topBar"
         android:layout_width="match_parent"
         android:layout_height="80dp"
         android:background="@color/foundation_normal_theme"
-        app:layout_constraintBottom_toTopOf="@id/handle">
+        app:layout_constraintTop_toBottomOf="@+id/handle">
 
         <ImageButton
             android:id="@+id/exit_multi_select"
@@ -161,17 +162,18 @@
         android:background="@color/tab_tray_item_divider_normal_theme"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/topBar" />
+        app:layout_constraintTop_toBottomOf="@+id/topBar" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/tabsTray"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:clipToPadding="false"
+        android:paddingBottom="140dp"
         android:scrollbars="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/divider" />
+        app:layout_constraintTop_toBottomOf="@+id/divider" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/component_tabstray_fab.xml
+++ b/app/src/main/res/layout/component_tabstray_fab.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?><!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/new_tab_button"
+    style="@style/TabTrayFab"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="bottom|end"
+    android:scrollbars="none"
+    android:layout_margin="16dp"
+    android:backgroundTint="@color/accent_normal_theme"
+    android:contentDescription="@string/add_tab"
+    android:elevation="99dp"
+    android:text="@string/tab_drawer_fab_content"
+    android:textColor="@color/photonWhite"
+    app:elevation="99dp"
+    app:borderWidth="0dp"
+    app:icon="@drawable/ic_new"
+    app:iconTint="@color/photonWhite" />

--- a/app/src/main/res/layout/component_tabstray_fab_top.xml
+++ b/app/src/main/res/layout/component_tabstray_fab_top.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?><!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/new_tab_button"
+    style="@style/TabTrayFab"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="top|end"
+    android:scrollbars="none"
+    android:layout_margin="16dp"
+    android:backgroundTint="@color/accent_normal_theme"
+    android:contentDescription="@string/add_tab"
+    android:elevation="99dp"
+    android:text="@string/tab_drawer_fab_content"
+    android:textColor="@color/photonWhite"
+    app:elevation="99dp"
+    app:borderWidth="0dp"
+    app:icon="@drawable/ic_new"
+    app:iconTint="@color/photonWhite" />

--- a/app/src/main/res/layout/component_tabstray_top.xml
+++ b/app/src/main/res/layout/component_tabstray_top.xml
@@ -6,45 +6,44 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/tab_wrapper"
-    style="@style/BottomSheetModal"
+    style="@style/TopSheetModal"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:backgroundTint="@color/foundation_normal_theme"
-    app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
+    app:layout_behavior="org.mozilla.fenix.components.topsheet.TopSheetBehavior">
 
     <View
         android:id="@+id/handle"
         android:layout_width="0dp"
         android:layout_height="3dp"
-        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
         android:background="@color/secondary_text_normal_theme"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintWidth_percent="0.1" />
 
     <TextView
         android:id="@+id/tab_tray_empty_view"
         android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
         android:focusable="true"
         android:focusableInTouchMode="true"
         android:gravity="center_horizontal"
-        android:paddingTop="80dp"
+        android:paddingBottom="80dp"
         android:text="@string/no_open_tabs_description"
         android:textColor="?secondaryText"
         android:textSize="16sp"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/topBar" />
+        app:layout_constraintBottom_toTopOf="@+id/divider" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/topBar"
         android:layout_width="match_parent"
         android:layout_height="80dp"
         android:background="@color/foundation_normal_theme"
-        app:layout_constraintTop_toBottomOf="@+id/handle">
+        app:layout_constraintBottom_toTopOf="@id/handle">
 
         <ImageButton
             android:id="@+id/exit_multi_select"
@@ -162,18 +161,17 @@
         android:background="@color/tab_tray_item_divider_normal_theme"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/topBar" />
+        app:layout_constraintBottom_toTopOf="@+id/topBar" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/tabsTray"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:clipToPadding="false"
-        android:paddingBottom="140dp"
         android:scrollbars="vertical"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/divider" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/divider" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -123,6 +123,15 @@
     <string name="pref_key_auto_battery_theme" translatable="false">pref_key_auto_battery_theme</string>
     <string name="pref_key_follow_device_theme" translatable="false">pref_key_follow_device_theme</string>
 
+    <!-- Tab Tray Customization Settings -->
+    <string name="pref_key_tab_tray_same_direction" translatable="false">pref_key_tab_tray_same_direction</string>
+    <string name="pref_key_tab_tray_opposite_direction" translatable="false">pref_key_tab_tray_opposite_direction</string>
+    <string name="pref_key_tab_tray_always_top" translatable="false">pref_key_tab_tray_always_top</string>
+    <string name="pref_key_tab_tray_always_bottom" translatable="false">pref_key_tab_tray_always_bottom</string>
+    <string name="pref_key_tab_tray_new_tab_fab" translatable="false">pref_key_tab_tray_new_tab_fab</string>
+    <string name="pref_key_tab_tray_new_tab_bar" translatable="false">pref_key_tab_tray_new_tab_bar</string>
+
+
     <!-- Customization Settings -->
     <string name="pref_home_category" translatable="false">pref_home_category</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -278,6 +278,10 @@
     <string name="preferences_sign_in">Sign in</string>
     <!-- Preference for changing where the toolbar is positioned -->
     <string name="preferences_toolbar">Toolbar</string>
+    <!-- Preference for changing from which direction the tabs tray opens -->
+    <string name="preferences_tab_tray_direction">Tabs Tray open direction</string>
+    <!-- Preference for changing how to display the new tab button -->
+    <string name="preferences_tab_tray_new_tab_type">New Tab Button Type</string>
     <!-- Preference for changing default theme to dark or light mode -->
     <string name="preferences_theme">Theme</string>
     <!-- Preference for customizing the home screen -->
@@ -444,6 +448,20 @@
     <string name="preference_top_toolbar">Top</string>
     <!-- Preference for using bottom toolbar -->
     <string name="preference_bottom_toolbar">Bottom</string>
+
+    <!-- Tabs Tray Preferences -->
+    <!-- Preference for opening the tabs tray from the same direction as the toolbar -->
+    <string name="preference_tab_tray_same_direction">From the same direction as the toolbar</string>
+    <!-- Preference for opening the tabs tray from the opposite direction as the toolbar -->
+    <string name="preference_tab_tray_opposite_direction">From the opposite direction as the toolbar</string>
+    <!-- Preference for opening the tabs tray from top -->
+    <string name="preference_tab_tray_always_top">Always from top</string>
+    <!-- Preference for opening the tabs tray from bottom -->
+    <string name="preference_tab_tray_always_bottom">Always from bottom</string>
+    <!-- Preference for using the fab new tab button -->
+    <string name="preference_tab_tray_new_tab_fab">FAB (Floating Action Button)</string>
+    <!-- Preference for opening the tabs tray from bottom -->
+    <string name="preference_tab_tray_new_tab_bar">Add a button to the bar</string>
 
     <!-- Theme Preferences -->
     <!-- Preference for using light theme -->

--- a/app/src/main/res/xml/customization_preferences.xml
+++ b/app/src/main/res/xml/customization_preferences.xml
@@ -51,6 +51,38 @@
     </androidx.preference.PreferenceCategory>
 
     <androidx.preference.PreferenceCategory
+        android:layout="@layout/preference_cat_style"
+        android:title="@string/preferences_tab_tray_direction"
+        app:allowDividerAbove="false"
+        app:iconSpaceReserved="false">
+        <org.mozilla.fenix.settings.RadioButtonPreference
+            android:key="@string/pref_key_tab_tray_same_direction"
+            android:title="@string/preference_tab_tray_same_direction" />
+        <org.mozilla.fenix.settings.RadioButtonPreference
+            android:key="@string/pref_key_tab_tray_opposite_direction"
+            android:title="@string/preference_tab_tray_opposite_direction" />
+        <org.mozilla.fenix.settings.RadioButtonPreference
+            android:key="@string/pref_key_tab_tray_always_top"
+            android:title="@string/preference_tab_tray_always_top" />
+        <org.mozilla.fenix.settings.RadioButtonPreference
+            android:key="@string/pref_key_tab_tray_always_bottom"
+            android:title="@string/preference_tab_tray_always_bottom" />
+    </androidx.preference.PreferenceCategory>
+
+    <androidx.preference.PreferenceCategory
+        android:layout="@layout/preference_cat_style"
+        android:title="@string/preferences_tab_tray_new_tab_type"
+        app:allowDividerAbove="false"
+        app:iconSpaceReserved="false">
+        <org.mozilla.fenix.settings.RadioButtonPreference
+            android:key="@string/pref_key_tab_tray_new_tab_bar"
+            android:title="@string/preference_tab_tray_new_tab_bar" />
+        <org.mozilla.fenix.settings.RadioButtonPreference
+            android:key="@string/pref_key_tab_tray_new_tab_fab"
+            android:title="@string/preference_tab_tray_new_tab_fab" />
+    </androidx.preference.PreferenceCategory>
+
+    <androidx.preference.PreferenceCategory
         android:key="@string/pref_home_category"
         android:layout="@layout/preference_cat_style"
         android:title="@string/preferences_home"


### PR DESCRIPTION
Adds an option to bring back the fab and to select a direction to open the tab tray.
@abhijitvalluri could you review? :)
The default is still the same as before.
Maybe someone could suggest better strings for the settings? I don't think they're currently very good.
screenshots: 
![Screenshot_20200903-162839_Iceweasel Preview](https://user-images.githubusercontent.com/44171190/92129235-8ad8d480-ee03-11ea-891f-719253670edf.jpg)
![Screenshot_20200903-164109_Iceweasel Preview](https://user-images.githubusercontent.com/44171190/92129801-47cb3100-ee04-11ea-8a8b-9e83b99aa2d8.jpg)


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
