### PR TITLE
Enable massive amount of tabs tray customization options!

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
@@ -57,6 +57,8 @@ class CustomizationFragment : PreferenceFragmentCompat() {
         bindAutoBatteryTheme()
         setupRadioGroups()
         setupToolbarCategory()
+        setupTabsTrayCategory()
+        setupFabCategory()
         setupHomeCategory()
         setupAddonsCustomizationCategory()
     }
@@ -142,10 +144,40 @@ class CustomizationFragment : PreferenceFragmentCompat() {
         addToRadioGroup(topPreference, bottomPreference)
     }
 
+    private fun setupTabsTrayCategory() {
+        requirePreference<SwitchPreference>(R.string.pref_key_tabs_tray_compact_tab).apply {
+            isChecked = context.settings().enableCompactTabs
+            onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
+
+        requirePreference<SwitchPreference>(R.string.pref_key_tabs_tray_top_tray).apply {
+            isChecked = context.settings().useTopTabsTray
+            onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
+
+        requirePreference<SwitchPreference>(R.string.pref_key_tabs_tray_reverse_tab_order).apply {
+            isChecked = context.settings().reverseTabOrderInTabsTray
+            onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
+    }
+
+    private fun setupFabCategory() {
+        requirePreference<SwitchPreference>(R.string.pref_key_tabs_tray_use_fab).apply {
+            isChecked = context.settings().useNewTabFloatingActionButton
+            onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
+
+        requirePreference<SwitchPreference>(R.string.pref_key_tabs_tray_fab_top_position).apply {
+            isChecked = context.settings().placeNewTabFloatingActionButtonAtTop
+            onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
+    }
+
     private fun setupHomeCategory() {
         requirePreference<PreferenceCategory>(R.string.pref_home_category).apply {
             isVisible = FeatureFlags.topFrecentSite
         }
+
         requirePreference<SwitchPreference>(R.string.pref_key_enable_top_frecent_sites).apply {
             isVisible = FeatureFlags.topFrecentSite
             isChecked = context.settings().showTopFrecentSites

--- a/app/src/main/java/org/mozilla/fenix/tabtray/FenixTabsAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/FenixTabsAdapter.kt
@@ -18,6 +18,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.metrics
+import org.mozilla.fenix.ext.settings
 
 class FenixTabsAdapter(
     private val context: Context,
@@ -26,7 +27,7 @@ class FenixTabsAdapter(
     viewHolderProvider = { parentView ->
         TabTrayViewHolder(
             LayoutInflater.from(context).inflate(
-                R.layout.tab_tray_item,
+                if (context.settings().enableCompactTabs) R.layout.tab_tray_item_compact else R.layout.tab_tray_item,
                 parentView,
                 false
             ),

--- a/app/src/main/java/org/mozilla/fenix/tabtray/SyncedTabsController.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/SyncedTabsController.kt
@@ -21,6 +21,7 @@ import mozilla.components.browser.storage.sync.SyncedDeviceTabs
 import mozilla.components.feature.syncedtabs.view.SyncedTabsView
 import mozilla.components.lib.state.ext.flowScoped
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
+import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.sync.ListenerDelegate
 import org.mozilla.fenix.sync.SyncedTabsAdapter
 import org.mozilla.fenix.sync.ext.toAdapterList
@@ -63,7 +64,11 @@ class SyncedTabsController(
     override fun displaySyncedTabs(syncedTabs: List<SyncedDeviceTabs>) {
         scope.launch {
             val tabsList = listOf(SyncedTabsAdapter.AdapterItem.Title) + syncedTabs.toAdapterList()
-            adapter.submitList(tabsList)
+            if (view.context.settings().reverseTabOrderInTabsTray) {
+                adapter.submitList(tabsList.reversed())
+            } else {
+                adapter.submitList(tabsList)
+            }
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
@@ -21,7 +21,8 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.component_tabstray.view.*
+import kotlinx.android.synthetic.main.component_tabstray_bottom.view.*
+import kotlinx.android.synthetic.main.component_tabstray_fab_bottom.view.*
 import kotlinx.android.synthetic.main.fragment_tab_tray_dialog.*
 import kotlinx.android.synthetic.main.fragment_tab_tray_dialog.view.*
 import kotlinx.coroutines.Dispatchers
@@ -66,7 +67,8 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), UserInteractionHandler 
     private lateinit var tabTrayDialogStore: TabTrayDialogFragmentStore
 
     private val snackbarAnchor: View?
-        get() = null
+        get() = if (tabTrayView.fabView.new_tab_button.isVisible) tabTrayView.fabView.new_tab_button
+        else null
 
     private val collectionStorageObserver = object : TabCollectionStorage.Observer {
         override fun onCollectionCreated(title: String, sessions: List<Session>) {

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -875,6 +875,31 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         BuildConfig.AMO_COLLECTION
     )
 
+    val enableCompactTabs by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_tabs_tray_compact_tab),
+        default = false
+    )
+
+    val useTopTabsTray by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_tabs_tray_top_tray),
+        default = false
+    )
+
+    val reverseTabOrderInTabsTray by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_tabs_tray_reverse_tab_order),
+        default = true
+    )
+
+    val useNewTabFloatingActionButton by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_tabs_tray_use_fab),
+        default = true
+    )
+
+    val placeNewTabFloatingActionButtonAtTop by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_tabs_tray_fab_top_position),
+        default = false
+    )
+
     private var savedLoginsSortingStrategyString by stringPreference(
         appContext.getPreferenceKey(R.string.pref_key_saved_logins_sorting_strategy),
         default = SavedLoginsSortingStrategyMenu.Item.AlphabeticallySort.strategyString

--- a/app/src/main/res/layout/component_tabstray_bottom.xml
+++ b/app/src/main/res/layout/component_tabstray_bottom.xml
@@ -6,44 +6,45 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/tab_wrapper"
-    style="@style/TopSheetModal"
+    style="@style/BottomSheetModal"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:backgroundTint="@color/foundation_normal_theme"
-    app:layout_behavior="org.mozilla.fenix.components.topsheet.TopSheetBehavior">
+    app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
 
     <View
         android:id="@+id/handle"
         android:layout_width="0dp"
         android:layout_height="3dp"
-        android:layout_marginBottom="8dp"
+        android:layout_marginTop="8dp"
         android:background="@color/secondary_text_normal_theme"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintWidth_percent="0.1" />
 
     <TextView
         android:id="@+id/tab_tray_empty_view"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         android:focusable="true"
         android:focusableInTouchMode="true"
         android:gravity="center_horizontal"
-        android:paddingBottom="80dp"
+        android:paddingTop="80dp"
         android:text="@string/no_open_tabs_description"
         android:textColor="?secondaryText"
         android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/divider" />
+        app:layout_constraintTop_toBottomOf="@id/topBar" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/topBar"
         android:layout_width="match_parent"
         android:layout_height="80dp"
         android:background="@color/foundation_normal_theme"
-        app:layout_constraintBottom_toTopOf="@id/handle">
+        app:layout_constraintTop_toBottomOf="@+id/handle">
 
         <ImageButton
             android:id="@+id/exit_multi_select"
@@ -161,17 +162,18 @@
         android:background="@color/tab_tray_item_divider_normal_theme"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/topBar" />
+        app:layout_constraintTop_toBottomOf="@+id/topBar" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/tabsTray"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:clipToPadding="false"
+        android:paddingBottom="140dp"
         android:scrollbars="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/divider" />
+        app:layout_constraintTop_toBottomOf="@+id/divider" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/component_tabstray_fab_bottom.xml
+++ b/app/src/main/res/layout/component_tabstray_fab_bottom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?><!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/new_tab_button"
+    style="@style/TabTrayFab"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="bottom|end"
+    android:scrollbars="none"
+    android:layout_margin="16dp"
+    android:backgroundTint="@color/accent_normal_theme"
+    android:contentDescription="@string/add_tab"
+    android:elevation="99dp"
+    android:text="@string/tab_drawer_fab_content"
+    android:textColor="@color/photonWhite"
+    app:elevation="99dp"
+    app:borderWidth="0dp"
+    app:icon="@drawable/ic_new"
+    app:iconTint="@color/photonWhite" />

--- a/app/src/main/res/layout/component_tabstray_fab_top.xml
+++ b/app/src/main/res/layout/component_tabstray_fab_top.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?><!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/new_tab_button"
+    style="@style/TabTrayFab"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="top|end"
+    android:scrollbars="none"
+    android:layout_margin="16dp"
+    android:backgroundTint="@color/accent_normal_theme"
+    android:contentDescription="@string/add_tab"
+    android:elevation="99dp"
+    android:text="@string/tab_drawer_fab_content"
+    android:textColor="@color/photonWhite"
+    app:elevation="99dp"
+    app:borderWidth="0dp"
+    app:icon="@drawable/ic_new"
+    app:iconTint="@color/photonWhite" />

--- a/app/src/main/res/layout/component_tabstray_top.xml
+++ b/app/src/main/res/layout/component_tabstray_top.xml
@@ -6,45 +6,44 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/tab_wrapper"
-    style="@style/BottomSheetModal"
+    style="@style/TopSheetModal"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:backgroundTint="@color/foundation_normal_theme"
-    app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
+    app:layout_behavior="org.mozilla.fenix.components.topsheet.TopSheetBehavior">
 
     <View
         android:id="@+id/handle"
         android:layout_width="0dp"
         android:layout_height="3dp"
-        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
         android:background="@color/secondary_text_normal_theme"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintWidth_percent="0.1" />
 
     <TextView
         android:id="@+id/tab_tray_empty_view"
         android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
         android:focusable="true"
         android:focusableInTouchMode="true"
         android:gravity="center_horizontal"
-        android:paddingTop="80dp"
+        android:paddingBottom="80dp"
         android:text="@string/no_open_tabs_description"
         android:textColor="?secondaryText"
         android:textSize="16sp"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/topBar" />
+        app:layout_constraintBottom_toTopOf="@+id/divider" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/topBar"
         android:layout_width="match_parent"
         android:layout_height="80dp"
         android:background="@color/foundation_normal_theme"
-        app:layout_constraintTop_toBottomOf="@+id/handle">
+        app:layout_constraintBottom_toTopOf="@id/handle">
 
         <ImageButton
             android:id="@+id/exit_multi_select"
@@ -162,18 +161,17 @@
         android:background="@color/tab_tray_item_divider_normal_theme"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/topBar" />
+        app:layout_constraintBottom_toTopOf="@+id/topBar" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/tabsTray"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:clipToPadding="false"
-        android:paddingBottom="140dp"
         android:scrollbars="vertical"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/divider" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/divider" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/tab_tray_item_compact.xml
+++ b/app/src/main/res/layout/tab_tray_item_compact.xml
@@ -7,7 +7,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/tab_item"
     android:layout_width="match_parent"
-    android:layout_height="88dp"
+    android:layout_height="165dp"
     android:clickable="true"
     android:focusable="true"
     android:foreground="?android:selectableItemBackground">
@@ -16,22 +16,21 @@
         android:id="@+id/play_pause_button"
         android:layout_width="24dp"
         android:layout_height="24dp"
-        android:layout_marginStart="80dp"
-        android:layout_marginTop="4dp"
+        android:layout_marginTop="23dp"
         android:background="?attr/selectableItemBackgroundBorderless"
         android:contentDescription="@string/mozac_feature_media_notification_action_pause"
         android:elevation="10dp"
         android:visibility="gone"
-        app:layout_constraintStart_toStartOf="@id/mozac_browser_tabstray_card"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/media_state_play" />
 
     <androidx.cardview.widget.CardView
         android:id="@+id/mozac_browser_tabstray_card"
-        android:layout_width="@dimen/tab_tray_thumbnail_width_original"
-        android:layout_height="@dimen/tab_tray_thumbnail_height_original"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="8dp"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/tab_tray_thumbnail_height"
+        android:layout_marginHorizontal="7dp"
+        android:layout_marginTop="30dp"
         android:backgroundTint="?tabTrayThumbnailItemBackground"
         app:cardBackgroundColor="@color/photonWhite"
         app:layout_constraintStart_toStartOf="parent"
@@ -78,9 +77,9 @@
         android:id="@+id/mozac_browser_tabstray_icon_card"
         android:layout_width="20dp"
         android:layout_height="20dp"
-        android:layout_marginStart="8dp"
-        app:layout_constraintStart_toEndOf="@id/mozac_browser_tabstray_card"
-        app:layout_constraintBottom_toBottomOf="@id/mozac_browser_tabstray_title"
+        app:layout_constraintStart_toStartOf="@id/mozac_browser_tabstray_card"
+        app:layout_constraintBottom_toTopOf="@id/mozac_browser_tabstray_card"
+        app:layout_constraintTop_toTopOf="parent"
         app:cardCornerRadius="5dp" >
 
         <ImageView
@@ -91,6 +90,7 @@
 
     </androidx.cardview.widget.CardView>
 
+
     <TextView
         android:id="@+id/mozac_browser_tabstray_title"
         android:layout_width="0dp"
@@ -100,13 +100,13 @@
         android:fadingEdgeLength="25dp"
         android:ellipsize="none"
         android:singleLine="true"
-        android:paddingStart="8dp"
-        android:paddingTop="22dp"
+        android:paddingHorizontal="7dp"
+        android:paddingVertical="5dp"
         android:textColor="@color/tab_tray_item_text_normal_theme"
-        android:textSize="16sp"
-        tools:text="This is the title of the tab and it is long"
+        android:textSize="14sp"
+        android:visibility="visible"
+        tools:text="Webpage tile that is long and will overflow textview widget"
         app:layout_constraintEnd_toStartOf="@id/mozac_browser_tabstray_close"
-        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toEndOf="@id/mozac_browser_tabstray_icon_card"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -115,14 +115,12 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
-        android:requiresFadingEdge="horizontal"
-        android:fadingEdgeLength="25dp"
-        android:ellipsize="none"
-        android:singleLine="true"
+        android:lines="1"
         android:paddingStart="8dp"
         android:textColor="@color/tab_tray_item_url_normal_theme"
         android:textSize="14sp"
         tools:text="https://www.google.com"
+        android:visibility="gone"
         app:layout_constraintEnd_toStartOf="@id/mozac_browser_tabstray_close"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toEndOf="@id/mozac_browser_tabstray_card"
@@ -130,12 +128,12 @@
 
     <androidx.appcompat.widget.AppCompatImageButton
         android:id="@+id/mozac_browser_tabstray_close"
-        android:layout_width="48dp"
-        android:layout_height="match_parent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:background="?android:attr/selectableItemBackgroundBorderless"
         android:contentDescription="@string/close_tab"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintEnd_toEndOf="@id/mozac_browser_tabstray_card"
+        app:layout_constraintBottom_toTopOf="@id/mozac_browser_tabstray_card"
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/mozac_ic_close"
         app:tint="@color/tab_tray_item_text_normal_theme" />

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -159,6 +159,9 @@
     <dimen name="tab_tray_top_offset">40dp</dimen>
     <dimen name="tab_tray_thumbnail_width">125dp</dimen>
     <dimen name="tab_tray_thumbnail_height">130dp</dimen>
+    <!-- Tabs Tray -->
+    <dimen name="tab_tray_thumbnail_width_original">92dp</dimen>
+    <dimen name="tab_tray_thumbnail_height_original">69dp</dimen>
 
     <!-- Saved Logins Fragment -->
     <dimen name="saved_logins_sort_menu_dropdown_chevron_icon_margin_start">10dp</dimen>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -126,6 +126,17 @@
     <!-- Customization Settings -->
     <string name="pref_home_category" translatable="false">pref_home_category</string>
 
+    <!-- Tabs Tray Customization Settings -->
+    <string name="pref_tabs_tray_settings_category" translatable="false">pref_tabs_tray_settings_category</string>
+    <string name="pref_key_tabs_tray_compact_tab" translatable="false">pref_key_tabs_tray_compact_tab</string>
+    <string name="pref_key_tabs_tray_top_tray" translatable="false">pref_key_tabs_tray_top_tray</string>
+    <string name="pref_key_tabs_tray_reverse_tab_order" translatable="false">pref_key_tabs_tray_reverse_tab_order</string>
+
+    <!-- Tabs Tray FAB Customization Settings -->
+    <string name="pref_tabs_tray_fab_settings_category" translatable="false">pref_tabs_tray_fab_settings_category</string>
+    <string name="pref_key_tabs_tray_use_fab" translatable="false">pref_key_tabs_tray_use_fab</string>
+    <string name="pref_key_tabs_tray_fab_top_position" translatable="false">pref_key_tabs_tray_fab_top_position</string>
+
     <!-- Add-ons Source Customization Settings -->
     <string name="pref_addons_settings_category" translatable="false">pref_addons_settings_category</string>
     <string name="pref_key_addons_custom_account" translatable="false">pref_key_addons_custom_account</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -282,6 +282,10 @@
     <string name="preferences_theme">Theme</string>
     <!-- Preference for customizing the home screen -->
     <string name="preferences_home">Home</string>
+    <!-- Preference for customizing the tabs tray -->
+    <string name="preferences_tabs_tray">Tabs tray</string>
+    <!-- Preference for customizing the tabs tray FAB -->
+    <string name="preferences_tabs_tray_fab">Floating action button (FAB)</string>
     <!-- Preference for settings related to visual options -->
     <string name="preferences_customize">Customize</string>
     <!-- Preference description for banner about signing in -->
@@ -1530,10 +1534,25 @@
     <!-- Label for the show most visited sites preference -->
     <string name="top_sites_toggle_top_frecent_sites">Show most visited sites</string>
 
-    <!-- Label for add-ons custom source account -->
+    <!-- Label for add-ons custom source account preference -->
     <string name="addons_custom_source_account">Set custom add-ons account</string>
-    <!-- Label for add-ons custom source collection -->
+    <!-- Label for add-ons custom source collection preference -->
     <string name="addons_custom_source_collection">Set custom add-ons collection</string>
+
+    <!-- Label for enable compact tabs in tabs tray preference -->
+    <string name="enable_compact_tabs">Enable compact tabs</string>
+    <!-- Label for enable top tabs tray preference -->
+    <string name="enable_top_tabs_tray">Enable top tabs tray</string>
+    <!-- Label for reverse tab order in tabs tray preference -->
+    <string name="reverse_tab_order_tabs_tray">Reverse tab order in tray</string>
+    <!-- Summary for reverse tab order preference -->
+    <string name="reverse_tab_order_description">Enable to put new tabs at start of the tabs list, disable to put new tabs at end of the tabs list</string>
+    <!-- Label for enable FAB in tabs tray preference -->
+    <string name="enable_fab_tabs_tray">Enable FAB for new tab</string>
+    <!-- Label for top FAB position in tabs tray preference -->
+    <string name="fab_tabs_tray_top">Place FAB at the top</string>
+    <!-- Label for top FAB position in tabs tray preference -->
+    <string name="fab_tabs_tray_top_description">Enable to place button for new tab at the top, disable to place it at the bottom</string>
 
     <!-- Content description for close button in collection placeholder. -->
     <string name="remove_home_collection_placeholder_content_description">Remove</string>

--- a/app/src/main/res/xml/customization_preferences.xml
+++ b/app/src/main/res/xml/customization_preferences.xml
@@ -35,7 +35,7 @@
     <androidx.preference.PreferenceCategory
         android:layout="@layout/preference_cat_style"
         android:title="@string/preferences_toolbar"
-        app:allowDividerAbove="false"
+        app:allowDividerAbove="true"
         app:iconSpaceReserved="false">
         <org.mozilla.fenix.settings.RadioButtonPreference
             android:key="@string/pref_key_toolbar_top"
@@ -51,10 +51,48 @@
     </androidx.preference.PreferenceCategory>
 
     <androidx.preference.PreferenceCategory
+        android:key="@string/pref_tabs_tray_settings_category"
+        android:layout="@layout/preference_cat_style"
+        android:title="@string/preferences_tabs_tray"
+        app:allowDividerAbove="true"
+        app:iconSpaceReserved="false">
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="@string/pref_key_tabs_tray_compact_tab"
+            android:title="@string/enable_compact_tabs" />
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="@string/pref_key_tabs_tray_top_tray"
+            android:title="@string/enable_top_tabs_tray" />
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="@string/pref_key_tabs_tray_reverse_tab_order"
+            android:title="@string/reverse_tab_order_tabs_tray"
+            android:summary="@string/reverse_tab_order_description" />
+    </androidx.preference.PreferenceCategory>
+
+    <androidx.preference.PreferenceCategory
+        android:key="@string/pref_tabs_tray_fab_settings_category"
+        android:layout="@layout/preference_cat_style"
+        android:title="@string/preferences_tabs_tray_fab"
+        app:allowDividerAbove="false"
+        app:iconSpaceReserved="false">
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="@string/pref_key_tabs_tray_use_fab"
+            android:title="@string/enable_fab_tabs_tray" />
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="@string/pref_key_tabs_tray_fab_top_position"
+            android:title="@string/fab_tabs_tray_top"
+            android:summary="@string/fab_tabs_tray_top_description" />
+    </androidx.preference.PreferenceCategory>
+
+    <androidx.preference.PreferenceCategory
         android:key="@string/pref_home_category"
         android:layout="@layout/preference_cat_style"
         android:title="@string/preferences_home"
-        app:allowDividerAbove="false"
+        app:allowDividerAbove="true"
         app:iconSpaceReserved="false"
         app:isPreferenceVisible="false">
         <androidx.preference.SwitchPreference
@@ -66,7 +104,7 @@
         android:key="@string/pref_addons_settings_category"
         android:layout="@layout/preference_cat_style"
         android:title="@string/preferences_addons_customization"
-        app:allowDividerAbove="false"
+        app:allowDividerAbove="true"
         app:iconSpaceReserved="false">
         <androidx.preference.EditTextPreference
             android:key="@string/pref_key_addons_custom_account"


### PR DESCRIPTION
This PR enables a totally insane amount of customization options for the tabs tray. For those who don't know, the "Tabs Tray" is the UI element that pops up (as a Bottom Sheet by default) with the list of open tabs, a button to save them to a collection and (if enabled in the secret settings) your synced tabs from other devices.

### Customization options
This PR enables the following customization options from the "Customize" menu item in settings:

* Enable compact tabs
    * Tabs are narrow and arranged in a grid, similar to how they were in the old Fennec version (v68). This was recently made mandatory by my earlier PR, but now it is configurable! This resolves issue #56!
* Enable top tabs tray
    * Tab tray opens from the top of the screen. This can be useful when the user chooses the toolbar to be at the bottom, so that the new tab button is easier to reach. My previous PR on this made this the mandatory layout when toolbar is placed at the bottom. But now it is independently configurabe and also resolves #55!
* Reverse tab order in tray
    * This reverses the order of the tabs in the tray so that new tabs appear towards the start of the tray. Note that the start of the tray means bottom of the tray when "top tabs tray" is enabled. This brings back the default ordering of tabs in Fenix!
* Enable FAB (Floating action button) for new tab
    * This brings back the FAB that was originally present in Fenix that I removed in my previous PR related to this.
* Place FAB at the top
    * This places the FAB at the top of the screen! A totally mad idea! Completely against material UI guidelines! But oh well, you gotta give users the power to do it! That is the ~~firefox~~ iceweasel (pending name change) way!

Note that this PR incorporates all the customization options implemented in #58 by @miDeb and adds a lot more options on top of that!

#### Default configuration

The default configuration on a fresh install is:
* Disable compact tabs
* Disable top tabs tray
* Enable reverse tab order in tray
* Enable FAB
* Place FAB at the bottom

This setup gives you the original Fenix layout, hence it makes sense to use this configuration to make the UI similar to Fenix for the least disruption.

In addition to these customization options, I updated the layout in the list view (i.e. non-compact tabs view) to show the site favicon as well.

Finally, I tweaked the "Customize" settings page to add dividers between sections so that it is easier to read and navigate. Given that we are adding a lot of settings in this page, it becomes very busy and difficult to follow without these dividers.

This is the most configuration I can enable and willing to enable. There is not much more to do, and this was already quite a pain! 😅 

**NOTE**: I disabled a bit of code in `TabTrayView.kt` that was causing a crash when accessibilty settings (such as TalkBack) is enabled. This crash is related to this issue on the upstream Fenix repo that I created: https://github.com/mozilla-mobile/fenix/issues/14540. When the issue is resolved upstream, we will need to put some effort to merge it as it will very likely cause lot of merge conflicts!

### Screenshots
#### Customization options (with default configuration enabled)
<img src="https://user-images.githubusercontent.com/17151327/92180423-e2e0fc80-ee3e-11ea-8b07-4a6a5aeb8024.png" width="350" />

#### Various tabs tray layouts (not exhaustive)
<img src="https://user-images.githubusercontent.com/17151327/92180427-e4aac000-ee3e-11ea-9ba3-9db66997588d.png" width="350" /> <img src="https://user-images.githubusercontent.com/17151327/92180430-e5dbed00-ee3e-11ea-805c-bacf5d4d3912.png" width="350" /> <img src="https://user-images.githubusercontent.com/17151327/92180431-e6748380-ee3e-11ea-9372-a941b83a3ced.png" width="350" /> <img src="https://user-images.githubusercontent.com/17151327/92180432-e70d1a00-ee3e-11ea-8bf7-a91e0a0dc378.png" width="350" />
