### PR TITLE
Change what's new URL to fix #74

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/Config.kt
+++ b/app/src/main/java/org/mozilla/fenix/Config.kt
@@ -56,6 +56,16 @@ enum class ReleaseChannel {
      */
     val isFenix: Boolean
         get() = !isFennec
+        
+    /**
+     * Is this a rebranded fork?
+     */
+    val isFork: Boolean
+        get() =  when (this) {
+            ForkDebug -> true
+            ForkRelease -> true
+            else -> false
+        }
 }
 
 object Config {

--- a/app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt
@@ -86,6 +86,8 @@ object SupportUtils {
 
     fun getWhatsNewUrl(context: Context) = if (Config.channel.isFennec) {
         getGenericSumoURLForTopic(SumoTopic.UPGRADE_FAQ)
+    } else if (Config.channel.isFork) {
+        "https://github.com/fork-maintainers/iceweasel/releases"
     } else {
         getSumoURLForTopic(context, SumoTopic.WHATS_NEW)
     }


### PR DESCRIPTION
This changes the What's New option in the menu to link to our releases page, instead of Mozilla's news page.

There's still a bunch of other links in `app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt` to replace.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

I don't think the destination of this link is under test. The app UI hasn't changed at all, just the link destination.

