### PR TITLE
Add info for scaling of wordmark files

### DIFF
--- a/fork-asset-sources/wordmark_dpi
+++ b/fork-asset-sources/wordmark_dpi
@@ -1,7 +1,7 @@
 Scaling for wordmark files in app/src/forkRelease/res/drawable-*/ic_logo_wordmark_normal.png and app/src/forkRelease/res/drawable-*/ic_logo_wordmark_private.png
 This is the browser banner on the home page
 *normal.png is for light theme (use dark or black text)
-*private.png is for dark theme and private browsing (use white or ligh text)
+*private.png is for dark theme and private browsing (use white or light text)
 
 Scale to the following for the respective folders:
 *hdpi - 651x120

--- a/fork-asset-sources/wordmark_dpi
+++ b/fork-asset-sources/wordmark_dpi
@@ -1,0 +1,11 @@
+Scaling for wordmark files in app/src/forkRelease/res/drawable-*/ic_logo_wordmark_normal.png and app/src/forkRelease/res/drawable-*/ic_logo_wordmark_private.png
+This is the browser banner on the home page
+*normal.png is for light theme (use dark or black text)
+*private.png is for dark theme and private browsing (use white or ligh text)
+
+Scale to the following for the respective folders:
+*hdpi - 651x120
+*mdpi - 434x80
+*xdpi - 868x160
+*xxdpi - 1302x240
+*xxxdpi - 1736x320


### PR DESCRIPTION
This just adds a text file to fork-asset-sources with info for the scaling of the wordmark (banner) images, to make it easier on us to scale them properly when we update the files in the future.
I gathered this info from looking at each respective file upstream.

(I'm working on the wordmark banners for when/if we rebrand, that will come when a decision is made on the name.)