### PR TITLE
Upstream fixes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -229,7 +229,7 @@ android.applicationVariants.all { variant ->
 
     def isDebug = variant.buildType.resValues['IS_DEBUG']?.value ?: false
     def useReleaseVersioning = variant.buildType.buildConfigFields['USE_RELEASE_VERSIONING']?.value ?: false
-    def versionName = Config.releaseVersionName(project)
+    def versionName = Config.generateDebugVersionName()
 
     println("----------------------------------------------")
     println("Variant name:      " + variant.name)

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
@@ -262,14 +262,9 @@ class TabTrayView(
                     concatAdapter.addAdapter(syncedTabsController.adapter)
                 }
 
-                // Disabling the following block of code because it causes a crash when
-                // accessibility services are enabled! `notifyDataSetChanged()` is incompatible
-                // with concatAdapter. See: https://github.com/mozilla-mobile/fenix/issues/14540
-                // WARNING: Merging the upstream fix for this will cause lot of conflicts!
-                //
-                // if (hasAccessibilityEnabled) {
-                //    tabsAdapter.notifyItemRangeChanged(0, tabs.size)
-                // }
+                 if (hasAccessibilityEnabled) {
+                    tabsAdapter.notifyItemRangeChanged(0, tabs.size)
+                 }
 
                 if (!hasLoaded) {
                     hasLoaded = true

--- a/app/src/main/res/drawable/ic_new.xml
+++ b/app/src/main/res/drawable/ic_new.xml
@@ -8,6 +8,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="@color/primary_text_normal_theme"
+        android:fillColor="?primaryText"
         android:pathData="M13,4a1,1 0,1 0,-2 0v7H4a1,1 0,1 0,0 2h7v7a1,1 0,1 0,2 0v-7h7a1,1 0,1 0,0 -2h-7V4z" />
 </vector>

--- a/app/src/main/res/layout/component_tabs_screen_bottom.xml
+++ b/app/src/main/res/layout/component_tabs_screen_bottom.xml
@@ -151,6 +151,7 @@
             app:layout_constraintBottom_toBottomOf="@id/tab_layout"
             app:layout_constraintEnd_toStartOf="@id/tab_tray_overflow"
             app:layout_constraintTop_toTopOf="@id/tab_layout"
+            app:tint="@color/primary_text_normal_theme"
             app:srcCompat="@drawable/ic_new" />
 
         <ImageButton

--- a/app/src/main/res/layout/component_tabs_screen_top.xml
+++ b/app/src/main/res/layout/component_tabs_screen_top.xml
@@ -151,6 +151,7 @@
             app:layout_constraintBottom_toBottomOf="@id/tab_layout"
             app:layout_constraintEnd_toStartOf="@id/tab_tray_overflow"
             app:layout_constraintTop_toTopOf="@id/tab_layout"
+            app:tint="@color/primary_text_normal_theme"
             app:srcCompat="@drawable/ic_new" />
 
         <ImageButton

--- a/app/src/main/res/layout/component_tabstray_top.xml
+++ b/app/src/main/res/layout/component_tabstray_top.xml
@@ -138,6 +138,7 @@
             app:layout_constraintBottom_toBottomOf="@id/tab_layout"
             app:layout_constraintEnd_toStartOf="@id/tab_tray_overflow"
             app:layout_constraintTop_toTopOf="@id/tab_layout"
+            app:tint="@color/primary_text_normal_theme"
             app:srcCompat="@drawable/ic_new" />
 
         <ImageButton


### PR DESCRIPTION
Properly incorporate a few upstream fixes in the tabs tray component 
* crash when accessibility setting is enabled, code was commented out
* color of the new tab + button

Also, update build.gradle to use a proper version name for the builds. For some reason for me the version name is always null.