### PR TITLE
Add github actions workflows

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,0 +1,13 @@
+name: Android build
+on: pull_request
+jobs:
+  gradle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: assembleForkRelease -PversionName="$(git describe --tags HEAD)"

--- a/.github/workflows/android-testDebug.yml
+++ b/.github/workflows/android-testDebug.yml
@@ -1,0 +1,13 @@
+name: Android run tests
+on: pull_request
+jobs:
+  gradle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: -q testDebug 2>&1


### PR DESCRIPTION
Use github actions for CI. A little nicer than Travis and allows for multiple jobs parallelly and so can speed things up.