### PR TITLE
Rebrand README and app strings to Iceraven Browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Iceraven Browser! [![Build Status](https://travis-ci.org/fork-maintainers/iceweasel.svg?branch=fork)](https://travis-ci.org/fork-maintainers/iceweasel) ![Android build](https://github.com/fork-maintainers/iceweasel/workflows/Android%20build/badge.svg)
+# Iceraven Browser! [![Build Status](https://travis-ci.org/fork-maintainers/iceraven-browser.svg?branch=fork)](https://travis-ci.org/fork-maintainers/iceraven-browser) ![Android build](https://github.com/fork-maintainers/iceraven-browser/workflows/Android%20build/badge.svg)
 
 Definitely not brought to you by Mozilla!
 
@@ -8,7 +8,7 @@ Our goal is to be a close fork of the new Firefox for Android that seeks to prov
 
 Notable features include:
   * `about:config` support
-  * The ability to *attempt* to install a much longer list of add-ons than Mozilla's Fenix version of Firefox accepts. Currently the browser queries [this AMO collection](https://addons.mozilla.org/en-US/firefox/collections/16201230/What-I-want-on-Fenix/) **Most of them will not work**, because they depend on code that Mozilla is still working on writing in `android-components`, but you may attempt to install them. If you don't see an add-on you want, you can [request it](https://github.com/interfect/fenix/issues/new).
+  * The ability to *attempt* to install a much longer list of add-ons than Mozilla's Fenix version of Firefox accepts. Currently the browser queries [this AMO collection](https://addons.mozilla.org/en-US/firefox/collections/16201230/What-I-want-on-Fenix/) **Most of them will not work**, because they depend on code that Mozilla is still working on writing in `android-components`, but you may attempt to install them. If you don't see an add-on you want, you can [request it](https://github.com/fork-maintainers/iceraven-browser/issues/new).
   * **No warranties or guarantee of security or updates**. Binaries are currently are manually built and are not meaningfully signed. Why should you trust random people on the Internet to provide your web browser, one of the most important pieces of software you use? Iceraven Browser could not exist without the hardworking folks at the Mozilla Corporation who work on the Mozilla Android Components and Firefox projects, but it is not a Mozilla product, and is not provided, endorsed, vetted, approved, or secured by Mozilla.
 
 In addition, we intend to try to cut down on telemetry and proprietary code to as great of an extent as possible as long as doing so does not compromise the user experience or make the fork too hard to maintain. Right now, webelieve that no telemetry should be being sent to Mozilla anymore, but we cannot guarantee this; data may still be sent. **If you catch the app sending data to Mozilla, Adjust, Leanplum, Firebase, or any other such service, please open an issue!** Presumably data that reaches Mozilla is governed by Mozilla's privacy policy, but as Iceraven Browser is, again **not a Mozilla product**, we can make no promises.
@@ -19,7 +19,7 @@ That said, Iceraven Browser is an independent all-volunteer project, and has no 
 
 ## Installation
 
-[**Download APKs from the Releases Page**](https://github.com/interfect/fenix/releases)
+[**Download APKs from the Releases Page**](https://github.com/fork-maintainers/iceraven-browser/releases)
 
 ## Building
 
@@ -51,13 +51,13 @@ cd ..
 2. Clone the project.
 
 ```sh
-git clone https://github.com/interfect/fenix
+git clone https://github.com/fork-maintainers/iceraven-browser
 ```
 
-4. Go inside `fenix`. That's where the build is coordinated from.
+4. Go inside `iceraven-browser`. That's where the build is coordinated from.
 
 ```sh
-cd fenix
+cd iceraven-browser
 ```
 
 5. Configure the project. We need to set the release builds to be signed with the debug key, because proper code signing isn't set up yet and the completely unsigned APKs that are produced by default cannot be installed.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,21 @@
-# Iceweasel Mobile! [![Build Status](https://travis-ci.org/fork-maintainers/iceweasel.svg?branch=fork)](https://travis-ci.org/fork-maintainers/iceweasel) ![Android build](https://github.com/fork-maintainers/iceweasel/workflows/Android%20build/badge.svg)
+# Iceraven Browser! [![Build Status](https://travis-ci.org/fork-maintainers/iceweasel.svg?branch=fork)](https://travis-ci.org/fork-maintainers/iceweasel) ![Android build](https://github.com/fork-maintainers/iceweasel/workflows/Android%20build/badge.svg)
 
 Definitely not brought to you by Mozilla!
 
-Iceweasel Mobile is a web browser for Android, based on [Mozilla's Fenix version of Firefox](https://github.com/mozilla-mobile/fenix/), [GeckoView](https://mozilla.github.io/geckoview/) and [Mozilla Android Components](https://mozac.org/).
+Iceraven Browser is a web browser for Android, based on [Mozilla's Fenix version of Firefox](https://github.com/mozilla-mobile/fenix/), [GeckoView](https://mozilla.github.io/geckoview/) and [Mozilla Android Components](https://mozac.org/).
 
 Our goal is to be a close fork of the new Firefox for Android that seeks to provide users with more options, more opportunities to customize (including a broad extension library), and more information about the pages they visit and how their browsers are interacting with those pages.
 
 Notable features include:
   * `about:config` support
   * The ability to *attempt* to install a much longer list of add-ons than Mozilla's Fenix version of Firefox accepts. Currently the browser queries [this AMO collection](https://addons.mozilla.org/en-US/firefox/collections/16201230/What-I-want-on-Fenix/) **Most of them will not work**, because they depend on code that Mozilla is still working on writing in `android-components`, but you may attempt to install them. If you don't see an add-on you want, you can [request it](https://github.com/interfect/fenix/issues/new).
-  * **No warranties or guarantee of security or updates**. Binaries are currently are manually built and are not meaningfully signed. Why should you trust random people on the Internet to provide your web browser, one of the most important pieces of software you use? Iceweasel Mobile could not exist without the hardworking folks at the Mozilla Corporation who work on the Mozilla Android Components and Firefox projects, but it is not a Mozilla product, and is not provided, endorsed, vetted, approved, or secured by Mozilla.
+  * **No warranties or guarantee of security or updates**. Binaries are currently are manually built and are not meaningfully signed. Why should you trust random people on the Internet to provide your web browser, one of the most important pieces of software you use? Iceraven Browser could not exist without the hardworking folks at the Mozilla Corporation who work on the Mozilla Android Components and Firefox projects, but it is not a Mozilla product, and is not provided, endorsed, vetted, approved, or secured by Mozilla.
 
-In addition, we intend to try to cut down on telemetry and proprietary code to as great of an extent as possible as long as doing so does not compromise the user experience or make the fork too hard to maintain. Right now, webelieve that no telemetry should be being sent to Mozilla anymore, but we cannot guarantee this; data may still be sent. **If you catch the app sending data to Mozilla, Adjust, Leanplum, Firebase, or any other such service, please open an issue!** Presumably data that reaches Mozilla is governed by Mozilla's privacy policy, but as Iceweasel Mobile is, again **not a Mozilla product**, we can make no promises.
+In addition, we intend to try to cut down on telemetry and proprietary code to as great of an extent as possible as long as doing so does not compromise the user experience or make the fork too hard to maintain. Right now, webelieve that no telemetry should be being sent to Mozilla anymore, but we cannot guarantee this; data may still be sent. **If you catch the app sending data to Mozilla, Adjust, Leanplum, Firebase, or any other such service, please open an issue!** Presumably data that reaches Mozilla is governed by Mozilla's privacy policy, but as Iceraven Browser is, again **not a Mozilla product**, we can make no promises.
 
-Iceweasel Mobile combines the power of Fenix (of which we are a fork) and the spirit of Fennec, with a respectful nod toward the grand tradition of Netscape Navigator, from which all Gecko-based projects came, including the earliest of our predecessors, the old Mozilla Phoenix and Mozilla Firefox desktop browsers.
+Iceraven Browser combines the power of Fenix (of which we are a fork) and the spirit of Fennec, with a respectful nod toward the grand tradition of Netscape Navigator, from which all Gecko-based projects came, including the earliest of our predecessors, the old Mozilla Phoenix and Mozilla Firefox desktop browsers.
 
-Iceweasel Mobile also honors the spirit of the Debian Iceweasel desktop Firefox forks of 2005, for which we are named. We have **no affiliation** with ([Parabola GNU/Linux-libre](https://www.parabola.nu/)), current maintainers of the "Iceweasel" desktop browser.
-
-That said, Iceweasel Mobile is an independent all-volunteer project, and has no affiliation with Netscape, Netscape Navigator, Mozilla, Mozilla Firefox, Mozila Phoenix, Debian, Debian Iceweasel, Parabola GNU/Linux-libre Iceweasel, America Online, or Verizon, among others. :)  Basically, if you don't like the browser, it's not their fault. :)
+That said, Iceraven Browser is an independent all-volunteer project, and has no affiliation with Netscape, Netscape Navigator, Mozilla, Mozilla Firefox, Mozila Phoenix, Debian, Debian Iceraven, Parabola GNU/Linux-libre Iceraven, America Online, or Verizon, among others. :)  Basically, if you don't like the browser, it's not their fault. :)
 
 ## Installation
 
@@ -68,7 +66,7 @@ cd fenix
 echo "autosignReleaseWithDebugKey=" >>local.properties
 ```
 
-6. Build the project. To build the Iceweasel-branded release APKs, you can do:
+6. Build the project. To build the Iceraven-branded release APKs, you can do:
 
 ```sh
 ./gradlew assembleForkRelease -PversionName="$(git describe --tags HEAD)"

--- a/app/src/forkRelease/res/values/static_strings.xml
+++ b/app/src/forkRelease/res/values/static_strings.xml
@@ -4,5 +4,5 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <resources>
     <!-- Name of the application -->
-    <string name="app_name" translatable="false">Iceweasel</string>
+    <string name="app_name" translatable="false">Iceraven</string>
 </resources>

--- a/app/src/main/res/values-ru/static_strings.xml
+++ b/app/src/main/res/values-ru/static_strings.xml
@@ -15,7 +15,7 @@
 
     <!-- MP Migration -->
     <string name="mp_homescreen_tip_title">Ищете свои логины?</string>
-    <string name="mp_homescreen_tip_message">Если у вас был мастер-пароль до обновления Iceweasel, вам нужно будет ввести его, чтобы перенести сохранённые логины.</string>
+    <string name="mp_homescreen_tip_message">Если у вас был мастер-пароль до обновления Iceraven, вам нужно будет ввести его, чтобы перенести сохранённые логины.</string>
     <string name="mp_homescreen_button">Введите мастер-пароль</string>
     <string name="mp_dialog_title_recovery_transfer_saved_logins">Перенести сохранённые логины</string>
     <string name="mp_dialog_message_recovery_transfer_saved_logins">Введите свой предыдущий мастер-пароль.</string>
@@ -23,7 +23,7 @@
     <string name="mp_dialog_negative_transfer_saved_logins">Отмена</string>
     <string name="mp_dialog_error_transfer_saved_logins">Неправильный пароль</string>
     <string name="mp_dialog_title_transfer_success">Перенесено успешно</string>
-    <string name="mp_dialog_message_transfer_success">Ваши сохранённые логины были перенесены в Iceweasel.</string>
+    <string name="mp_dialog_message_transfer_success">Ваши сохранённые логины были перенесены в Iceraven.</string>
     <string name="mp_dialog_positive_transfer_success">Просмотр сохранённых логинов</string>
     <string name="mp_dialog_close_transfer">Закрыть</string>
     <string name="mp_dialog_title_transfer_failure">Перенос не удался</string>

--- a/app/src/main/res/values/static_strings.xml
+++ b/app/src/main/res/values/static_strings.xml
@@ -4,7 +4,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <resources>
     <!-- Name of the application -->
-    <string name="app_name" translatable="false">Iceweasel Preview</string>
+    <string name="app_name" translatable="false">Iceraven Preview</string>
 
     <!-- Preference for developers -->
     <string name="preference_leakcanary" translatable="false">LeakCanary</string>
@@ -43,11 +43,11 @@
     <string name="link_text_view_type_announcement" translatable="false">link</string>
 
     <!-- Name of the application for about page -->
-    <string name="daylight_app_name" translatable="false">Iceweasel</string>
+    <string name="daylight_app_name" translatable="false">Iceraven</string>
 
     <!-- MP Migration -->
     <string name="mp_homescreen_tip_title">Looking for your logins?</string>
-    <string name="mp_homescreen_tip_message">If you had a master password before Iceweasel updated, you’ll need to enter it to transfer your saved logins.</string>
+    <string name="mp_homescreen_tip_message">If you had a master password before Iceraven updated, you’ll need to enter it to transfer your saved logins.</string>
     <string name="mp_homescreen_button">Enter master password</string>
     <string name="mp_dialog_title_recovery_transfer_saved_logins">Transfer saved logins</string>
     <string name="mp_dialog_message_recovery_transfer_saved_logins">Enter your previous master password.</string>
@@ -55,7 +55,7 @@
     <string name="mp_dialog_negative_transfer_saved_logins">Cancel</string>
     <string name="mp_dialog_error_transfer_saved_logins">Invalid password</string>
     <string name="mp_dialog_title_transfer_success">Transfer successful</string>
-    <string name="mp_dialog_message_transfer_success">Your saved logins have been transferred to Iceweasel.</string>
+    <string name="mp_dialog_message_transfer_success">Your saved logins have been transferred to Iceraven.</string>
     <string name="mp_dialog_positive_transfer_success">View saved logins</string>
     <string name="mp_dialog_close_transfer">Close</string>
     <string name="mp_dialog_title_transfer_failure">Transfer failed</string>

--- a/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingHeaderViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingHeaderViewHolderTest.kt
@@ -29,6 +29,6 @@ class OnboardingHeaderViewHolderTest {
     fun `bind header text`() {
         OnboardingHeaderViewHolder(view)
 
-        assertEquals("Welcome to Iceweasel Preview!", view.header_text.text)
+        assertEquals("Welcome to Iceraven Preview!", view.header_text.text)
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingWhatsNewViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingWhatsNewViewHolderTest.kt
@@ -56,7 +56,7 @@ class OnboardingWhatsNewViewHolderTest {
         OnboardingWhatsNewViewHolder(view, interactor)
 
         assertEquals(
-            "Have questions about the redesigned Iceweasel Preview? Want to know what’s changed?",
+            "Have questions about the redesigned Iceraven Preview? Want to know what’s changed?",
             view.description_text.text
         )
 


### PR DESCRIPTION
This changes the user-facing strings and the README to say we are `Iceraven` and not `Iceweasel`.

This is part of #111.