### PR TITLE
Fix #131 by accepting -PversionName= again

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -231,7 +231,7 @@ android.applicationVariants.all { variant ->
 
     def isDebug = variant.buildType.resValues['IS_DEBUG']?.value ?: false
     def useReleaseVersioning = variant.buildType.buildConfigFields['USE_RELEASE_VERSIONING']?.value ?: false
-    def versionName = Config.generateDebugVersionName()
+    def versionName = Config.releaseVersionName(project) == "" ? Config.generateDebugVersionName() : Config.releaseVersionName(project)
 
     println("----------------------------------------------")
     println("Variant name:      " + variant.name)


### PR DESCRIPTION
This lets the build system use a `-PversionName=` argument if you provide one. This lets you set the version name for releases to the Git tag name, which is more informative than the auto-generated version names.
