### PR TITLE
Die For Your RAM

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -326,7 +326,22 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
 
         runOnlyInMainProcess {
             components.core.icons.onTrimMemory(level)
-            components.core.store.dispatch(SystemAction.LowMemoryAction(level))
+            
+            // We want to be judicious in passing low mamory messages to
+            // android-components, because it is (at time of writing) hardcoded
+            // to drop tab states (and any user data in them) as soon as we
+            // reach "moderate" memory pressure on the system, even if the
+            // browser is in no danger of being killed. See
+            // https://github.com/mozilla-mobile/android-components/blob/38186676d46c555b5a24268e5fa361e45e57102c/components/browser/session/src/main/java/mozilla/components/browser/session/engine/middleware/TrimMemoryMiddleware.kt#L53-L64
+            // for the relvant android-components code and
+            // https://stuff.mit.edu/afs/sipb/project/android/docs/reference/android/content/ComponentCallbacks2.html
+            // for the list of memory pressure levels.
+            val settings = this.settings()
+            if (settings.shouldRelinquishMemoryUnderPressure) {
+                // We will give up our RAM when asked nicely
+                components.core.store.dispatch(SystemAction.LowMemoryAction(level))
+            }
+            // Otherwise we will die for our RAM, if pressed.
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -326,7 +326,7 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
 
         runOnlyInMainProcess {
             components.core.icons.onTrimMemory(level)
-            
+
             // We want to be judicious in passing low mamory messages to
             // android-components, because it is (at time of writing) hardcoded
             // to drop tab states (and any user data in them) as soon as we

--- a/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
@@ -64,6 +64,7 @@ class CustomizationFragment : PreferenceFragmentCompat() {
         setupHomeCategory()
         setupGesturesCategory()
         setupAddonsCustomizationCategory()
+        setupSystemBehaviorCategory()
     }
 
     private fun setupRadioGroups() {
@@ -253,6 +254,13 @@ class CustomizationFragment : PreferenceFragmentCompat() {
 
         requirePreference<EditTextPreference>(R.string.pref_key_addons_custom_collection).apply {
             text = context.settings().customAddonsCollection
+            onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
+    }
+    
+    private fun setupSystemBehaviorCategory() {
+        requirePreference<SwitchPreference>(R.string.pref_key_relinquish_memory_under_pressure).apply {
+            isChecked = context.settings().shouldRelinquishMemoryUnderPressure
             onPreferenceChangeListener = SharedPreferenceUpdater()
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
@@ -257,7 +257,7 @@ class CustomizationFragment : PreferenceFragmentCompat() {
             onPreferenceChangeListener = SharedPreferenceUpdater()
         }
     }
-    
+
     private fun setupSystemBehaviorCategory() {
         requirePreference<SwitchPreference>(R.string.pref_key_relinquish_memory_under_pressure).apply {
             isChecked = context.settings().shouldRelinquishMemoryUnderPressure

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -550,6 +550,11 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         appContext.getPreferenceKey(R.string.pref_key_strip_url),
         default = true
     )
+    
+    var shouldRelinquishMemoryUnderPressure by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_relinquish_memory_under_pressure),
+        default = true
+    )
 
     /**
      * Check each active accessibility service to see if it can perform gestures, if any can,

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -550,7 +550,7 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         appContext.getPreferenceKey(R.string.pref_key_strip_url),
         default = true
     )
-    
+
     var shouldRelinquishMemoryUnderPressure by booleanPreference(
         appContext.getPreferenceKey(R.string.pref_key_relinquish_memory_under_pressure),
         default = true

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -133,7 +133,7 @@
     <string name="pref_key_dynamic_toolbar" translatable="false">pref_key_dynamic_toolbar</string>
     <string name="pref_key_swipe_toolbar_switch_tabs" translatable="false">pref_key_swipe_toolbar_switch_tabs</string>
     <string name="pref_key_swipe_toolbar_show_tabs" translatable="false">pref_key_swipe_toolbar_show_tabs</string>
-
+    
     <!-- Tabs Tray Customization Settings -->
     <string name="pref_tabs_tray_settings_category" translatable="false">pref_tabs_tray_settings_category</string>
     <string name="pref_key_tabs_tray_compact_tab" translatable="false">pref_key_tabs_tray_compact_tab</string>
@@ -151,6 +151,10 @@
     <string name="pref_addons_settings_category" translatable="false">pref_addons_settings_category</string>
     <string name="pref_key_addons_custom_account" translatable="false">pref_key_addons_custom_account</string>
     <string name="pref_key_addons_custom_collection" translatable="false">pref_key_addons_custom_collection</string>
+    
+    <!-- System Customization Settings -->
+    <string name="pref_system_behavior_settings_category" translatable="false">pref_system_behavior_settings_category</string>
+    <string name="pref_key_relinquish_memory_under_pressure" translatable="false">pref_key_relinquish_memory_under_pressure</string>
 
     <!-- Tracking Protection Settings -->
     <string name="pref_key_etp_learn_more" translatable="false">pref_key_etp_learn_more</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1585,6 +1585,13 @@
     <string name="addons_custom_source_account">Set custom add-ons account</string>
     <!-- Label for add-ons custom source collection preference -->
     <string name="addons_custom_source_collection">Set custom add-ons collection</string>
+    
+    <!-- Preference category for system behavior customization -->
+    <string name="preferences_system_behavior">Configure system behavior</string>
+    <!-- Title for relinquish memory preference in customization settings -->
+    <string name="preferences_relinquish_memory_title">Suspend tabs to avoid being killed for memory</string>
+    <!-- Description for relinquish memory preference in customization settings -->
+    <string name="preferences_relinquish_memory_description">If enabled, tabs will be suspended and page state lost when the system is low on memory</string>
 
     <!-- Label for enable compact tabs in tabs tray preference -->
     <string name="enable_compact_tabs">Enable compact tabs</string>

--- a/app/src/main/res/xml/customization_preferences.xml
+++ b/app/src/main/res/xml/customization_preferences.xml
@@ -138,4 +138,17 @@
             android:title="@string/addons_custom_source_collection" />
     </androidx.preference.PreferenceCategory>
     
+    <androidx.preference.PreferenceCategory
+        android:key="@string/pref_system_behavior_settings_category"
+        android:layout="@layout/preference_cat_style"
+        android:title="@string/preferences_system_behavior"
+        app:allowDividerAbove="true"
+        app:iconSpaceReserved="false">
+            <SwitchPreference
+            android:defaultValue="true"
+            android:key="@string/pref_key_relinquish_memory_under_pressure"
+            android:summary="@string/preferences_relinquish_memory_description"
+            android:title="@string/preferences_relinquish_memory_title" />
+    </androidx.preference.PreferenceCategory>
+    
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- This has been tested manually
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

![Screenshot_20200925-212518_Iceraven_Preview](https://user-images.githubusercontent.com/752054/94330103-cdf71500-ff75-11ea-9e4a-6d0b7cd972ef.png)

This adds a setting to fix #115 by letting you hide all memory pressure messages from the part of the app that remembers tab page states. If you turn it off, the app will let itself be completely killed by Android before deleting any page states.

@izarsha @Namit-Nayan do either of you want to test one of these debug APKs and see if you can make it drop tabs? 
[arm64](https://files.novak.network/f/4e822f759de34744b847/?dl=1)
[arm](https://files.novak.network/f/e1328f4cb77f4f879811/?dl=1)


 

