### PR TITLE
Let github actions upload the apk built during CI

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
+      - name: Create local.properties (to sign release apk with debug keys)
+        run: echo "autosignReleaseWithDebugKey=" >local.properties
       - name: Build forkRelease variant of app
         uses: eskatos/gradle-command-action@v1
         with:
@@ -23,6 +25,28 @@ jobs:
           dependencies-cache-enabled: true
           configuration-cache-enabled: true
           arguments: assembleForkRelease -PversionName="$(git describe --tags HEAD)"
+      - name: Archive arm64 apk
+        uses: actions/upload-artifact@v2
+        with:
+          name: app-arm64-v8a-forkRelease.apk
+          path: app/build/outputs/apk/forkRelease/app-arm64-v8a-forkRelease.apk
+      - name: Archive armeabi apk
+        uses: actions/upload-artifact@v2
+        with:
+          name: app-armeabi-v7a-forkRelease.apk
+          path: app/build/outputs/apk/forkRelease/app-armeabi-v7a-forkRelease.apk
+      - name: Archive x86 apk
+        uses: actions/upload-artifact@v2
+        with:
+          name: app-x86-forkRelease.apk
+          path: app/build/outputs/apk/forkRelease/app-x86-forkRelease.apk
+      - name: Archive x86_64 apk
+        uses: actions/upload-artifact@v2
+        with:
+          name: app-x86_64-forkRelease.apk
+          path: app/build/outputs/apk/forkRelease/app-x86_64-forkRelease.apk
+
+
   run-testDebug:
     runs-on: ubuntu-latest
     steps:
@@ -39,6 +63,8 @@ jobs:
           dependencies-cache-enabled: true
           configuration-cache-enabled: true
           arguments: testDebug
+
+
   run-detekt:
     runs-on: ubuntu-latest
     steps:
@@ -60,6 +86,8 @@ jobs:
         with:
           name: detekt report
           path: build/reports/detekt.html
+
+
   run-ktlint:
     runs-on: ubuntu-latest
     steps:
@@ -76,6 +104,8 @@ jobs:
           dependencies-cache-enabled: true
           configuration-cache-enabled: true
           arguments: ktlint
+
+
   run-lintDebug:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We can actually allow Github actions to upload the apks built in each CI run to the PR. This may make life easier for folks to test the code without having to checkout the branch and build it themselves! We *may* be able to use this to streamline releases as well? At the very least it can make it a tad easier to do so.

Initially I hesitated to do this as I thought storage for github actions is limited and we will not be able to upload too much because of these limits mentioned: https://docs.github.com/en/free-pro-team@latest/github/setting-up-and-managing-billing-and-payments-on-github/about-billing-for-github-actions#about-billing-for-github-actions

However, turns out it is completely free for open source projects (aka public repos)! I verified it by doing some tests myself in my repo and it says zero usage. [Github also clarified some vagueness in their documentation in the forums](https://github.community/t/do-build-artifacts-of-open-source-public-projects-count-towards-the-storage-limit/18277) that makes it unclear if storage is also free or if only [CI/CD is free](https://github.blog/2019-08-08-github-actions-now-supports-ci-cd/) for public repos. Essentially storage is also free!

If you want to be safe, you can set spending limits in your account or the organization's settings (wherever it needs to be) as explained [here](https://docs.github.com/en/free-pro-team@latest/github/setting-up-and-managing-billing-and-payments-on-github/managing-your-spending-limit-for-github-actions). It can future proof us in case Github changes its mind about things.