### PR TITLE
Put the comment on the PR after CI passes

### DIFF
--- a/.github/workflows/android-build-pr.yml
+++ b/.github/workflows/android-build-pr.yml
@@ -4,20 +4,6 @@ on:
     branches:
       - fork
 jobs:
-  comment-on-pr:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Comment on PR with link to checks page
-        uses: mshick/add-pr-comment@v1
-        with:
-          message: |
-            ### Download the built apks
-            You can download the apks built by Github actions **after** the CI checks pass.
-            Please go to the <a href="https://github.com/fork-maintainers/iceraven-browser/pull/${{ github.event.number }}/checks">checks page for this PR</a> to find the zipped apk files under the artifacts drop-down, as seen in the example screenshot below.
-
-            <img src="https://raw.githubusercontent.com/fork-maintainers/iceraven-browser/fork/.github/imgs/download-artifacts-screenshot.png" />
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          allow-repeats: false
   run-build:
     runs-on: ubuntu-latest
     steps:
@@ -56,7 +42,17 @@ jobs:
         with:
           name: app-x86_64-forkRelease.apk
           path: app/build/outputs/apk/forkRelease/app-x86_64-forkRelease.apk
+      - name: Comment on PR with link to checks page
+        uses: mshick/add-pr-comment@v1
+        with:
+          message: |
+            ### Download the built apks
+            You can download the apks built by Github actions after the CI checks pass.
+            Please go to the <a href="https://github.com/fork-maintainers/iceraven-browser/pull/${{ github.event.number }}/checks">checks page for this PR</a> to find the zipped apk files under the artifacts drop-down, as seen in the example screenshot below.
 
+            <img src="https://raw.githubusercontent.com/fork-maintainers/iceraven-browser/fork/.github/imgs/download-artifacts-screenshot.png" />
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-repeats: false
 
   run-testDebug:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Now that the commenting workflow is verified, tidying up the workflow. Put the comment on the PR **after** CI has passed, rather than immediately. 