### PR TITLE
Use real search engine list always when faking the location provider

### DIFF
--- a/app/src/forkDebug/java/org/mozilla/fenix/DebugFenixApplication.kt
+++ b/app/src/forkDebug/java/org/mozilla/fenix/DebugFenixApplication.kt
@@ -9,12 +9,11 @@ import androidx.preference.PreferenceManager
 import leakcanary.AppWatcher
 import leakcanary.LeakCanary
 import org.mozilla.fenix.ext.getPreferenceKey
-import org.mozilla.fenix.ext.resetPoliciesAfter
 
 class DebugFenixApplication : FenixApplication() {
 
     override fun setupLeakCanary() {
-        val isEnabled = StrictMode.allowThreadDiskReads().resetPoliciesAfter {
+        val isEnabled = components.strictMode.resetAfter(StrictMode.allowThreadDiskReads()) {
             PreferenceManager.getDefaultSharedPreferences(this)
                 .getBoolean(getPreferenceKey(R.string.pref_key_leakcanary), true)
         }

--- a/app/src/main/java/org/mozilla/fenix/components/searchengine/FenixSearchEngineProvider.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/searchengine/FenixSearchEngineProvider.kt
@@ -99,7 +99,7 @@ open class FenixSearchEngineProvider(
     // the main one hasn't completed yet
     private val searchEngines: Deferred<SearchEngineList>
         get() =
-            if (isRegionCachedByLocationService) {
+            if (isRegionCachedByLocationService || shouldMockMLS) {
                 loadedSearchEngines
             } else {
                 fallbackEngines


### PR DESCRIPTION
This should fix #166. I managed to add a custom search engine and it showed up.

![Screenshot_20201003-215557_Iceraven_Preview](https://user-images.githubusercontent.com/752054/95007376-d5489f00-05c3-11eb-8026-956c3d7dc496.png)

It also fixes `./gradlew assembleForkDebug`.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
The PR runs an Android build check (`run-build`) that builds a `forkRelease` variant of the app. If it succeeds, then we upload the apks (signed with debug keys) via Github actions. We also generate a comment with some instructions and a link to help you find the downloads. You can also follow the instructions below:
1. Click Details next to "run-build (pull_request_target)" after it finishes with a green checkmark.
2. Click the "Artifacts" drop-down near the top right of the page.
3. The apk links should be present in the drop-down menu. You can click on the suitable CPU architecture to download a zipped apk file.
4. Unzip the file and install the apk.
