### PR TITLE
Hide private browsing myths link

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -131,9 +131,6 @@ class HomeScreenTest {
             verifyPrivateSessionMessage()
             verifyHomeToolbar()
             verifyHomeComponent()
-        }.openCommonMythsLink {
-            verifyUrl("common-myths-about-private-browsing")
-            mDevice.pressBack()
         }
 
         homeScreen {

--- a/app/src/main/res/layout/private_browsing_description.xml
+++ b/app/src/main/res/layout/private_browsing_description.xml
@@ -39,5 +39,6 @@
         android:scrollHorizontally="false"
         android:text="@string/private_browsing_common_myths"
         android:textColor="?primaryText"
-        android:textSize="14sp" />
+        android:textSize="14sp"
+        android:visibility="gone" />
 </LinearLayout>


### PR DESCRIPTION
Also turn off Android test for it.

This is easier than actually writing our own documentation, disentangling the
link from the SUMO topic linking system, and changing the tests to respect the
new destination. The downside is that if users don't know what they're doing
with private browsing, we will no longer even try to help them.

This fixes #221.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
The PR runs an Android build check (`run-build`) that builds a `forkRelease` variant of the app. If it succeeds, then we upload the apks (signed with debug keys) via Github actions. We also generate a comment with some instructions and a link to help you find the downloads. You can also follow the instructions below:
1. Click Details next to "run-build (pull_request_target)" after it finishes with a green checkmark.
2. Click the "Artifacts" drop-down near the top right of the page.
3. The apk links should be present in the drop-down menu. You can click on the suitable CPU architecture to download a zipped apk file.
4. Unzip the file and install the apk.
